### PR TITLE
Virtual packages

### DIFF
--- a/dev/checks.nix
+++ b/dev/checks.nix
@@ -91,6 +91,11 @@ let
         packages = ps: [ ps."trivial" ];
       };
 
+      virtual = mkCheck {
+        root = ../lib/fixtures/virtual;
+        packages = ps: [ ps."virtual" ];
+      };
+
       workspace = mkCheck {
         root = ../lib/fixtures/workspace;
         packages = ps: [

--- a/lib/fixtures/virtual/pyproject.toml
+++ b/lib/fixtures/virtual/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "virtual"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "arpeggio>=2.0.2",
+]

--- a/lib/fixtures/virtual/src/trivial/__init__.py
+++ b/lib/fixtures/virtual/src/trivial/__init__.py
@@ -1,0 +1,2 @@
+def hello() -> str:
+    return "Hello from trivial!"

--- a/lib/fixtures/virtual/uv.lock
+++ b/lib/fixtures/virtual/uv.lock
@@ -1,0 +1,22 @@
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "arpeggio"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/c4/516bb54456f85ad1947702ea4cef543a59de66d31a9887dbc3d9df36e3e1/Arpeggio-2.0.2.tar.gz", hash = "sha256:c790b2b06e226d2dd468e4fbfb5b7f506cec66416031fde1441cf1de2a0ba700", size = 766643 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/4f/d28bf30a19d4649b40b501d531b44e73afada99044df100380fd9567e92f/Arpeggio-2.0.2-py2.py3-none-any.whl", hash = "sha256:f7c8ae4f4056a89e020c24c7202ac8df3e2bc84e416746f20b0da35bb1de0250", size = 55287 },
+]
+
+[[package]]
+name = "virtual"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "arpeggio" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "arpeggio", specifier = ">=2.0.2" }]

--- a/lib/lock1.nix
+++ b/lib/lock1.nix
@@ -229,6 +229,7 @@ fix (self: {
       isURL = source ? url;
       isDirectory = source ? directory; # Path to non-uv project
       isPath = source ? path; # Path to sdist
+      isVirtual = source ? virtual;
 
       # Wheels grouped by filename
       wheels = mapAttrs (
@@ -286,7 +287,7 @@ fix (self: {
           "pyproject";
 
     in
-    if (isProject || isDirectory) then
+    if (isProject || isDirectory || isVirtual) then
       buildPythonPackage (
         (
           if projects ? package.name then
@@ -298,6 +299,8 @@ fix (self: {
                   workspaceRoot + "/${source.editable}"
                 else if isDirectory then
                   workspaceRoot + "/${source.directory}"
+                else if isVirtual then
+                  workspaceRoot + "/${source.virtual}"
                 else
                   throw "Not a project path: ${builtins.toJSON source}";
             }


### PR DESCRIPTION
Create a test case for 'virtual' packages lacking build-system specification  (= dependency only packages)
(by branching of trivial), 
and add support support them.

See https://github.com/astral-sh/uv/blob/9edf2d8132355b56b9f64f1b6b3457e4f4919acf/uv.schema.json#L277