### PR TITLE
fix: add pkg to error msg if neither wheel nor sdist available

### DIFF
--- a/lib/renderers.nix
+++ b/lib/renderers.nix
@@ -121,10 +121,9 @@ in
             if preferWheel && compatibleWheels != [ ] then
               "wheel"
             else if package.sdist == { } then
-              assert compatibleWheels != [ ];
+              assert assertMsg (compatibleWheels != [ ]) "No compatible wheel, nor sdist found for package '${package.name}' ${package.version}";
               "wheel"
             else
-              assert package.sdist != { };
               "pyproject"
           )
         else


### PR DESCRIPTION
also remove an assert that can't trigger.