### PR TITLE
build: Implement pip fallback behaviour as default for sdist builds

### DIFF
--- a/dev/checks.nix
+++ b/dev/checks.nix
@@ -67,18 +67,9 @@ let
       hatch-vcs = [ ];
       hatch-fancy-pypi-readme = [ ];
     };
-    blinker.setuptools = [ ];
-    certifi.setuptools = [ ];
-    charset-normalizer.setuptools = [ ];
     idna.flit-core = [ ];
     urllib3.hatchling = [ ];
-    pip = {
-      setuptools = [ ];
-      wheel = [ ];
-    };
     packaging.flit-core = [ ];
-    requests.setuptools = [ ];
-    pysocks.setuptools = [ ];
   };
 
   # Assemble overlay from spec


### PR DESCRIPTION
This fallback behaviour as documented in:
- https://peps.python.org/pep-0517/#source-trees
- https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#fallback-behaviour

Once https://github.com/astral-sh/uv/issues/5190 has been resolved the empty build-time specification & fallback behaviour will be replaced with the one from `uv.lock`.

This will make anything that only uses setuptools as their build-system to work as sdist builds out of the box.

Closes https://github.com/nix-community/pyproject.nix/issues/169

cc @TyberiusPrime 