### PR TITLE
workspace: Add pre-defined dependency specifications

### DIFF
--- a/lib/test_workspace.nix
+++ b/lib/test_workspace.nix
@@ -57,6 +57,56 @@ in
     }
   ) workspaces;
 
+  loadWorkspace.deps =
+    let
+      mkTest =
+        workspaceRoot:
+        let
+          ws = workspace.loadWorkspace { inherit workspaceRoot; };
+        in
+        ws.deps;
+    in
+    {
+      testTrivial = {
+        expr = mkTest ./fixtures/trivial;
+        expected = {
+          all = {
+            trivial = [ ];
+          };
+          default = {
+            trivial = [ ];
+          };
+        };
+      };
+
+      testOptionalDeps = {
+        expr = mkTest ./fixtures/optional-deps;
+        expected = {
+          all = {
+            optional-deps = [ "haxx" ];
+          };
+          default = {
+            optional-deps = [ ];
+          };
+        };
+      };
+
+      testDependencyGroups = {
+        expr = mkTest ./fixtures/dependency-groups;
+        expected = {
+          all = {
+            dependency-groups = [
+              "dev"
+              "group-a"
+            ];
+          };
+          default = {
+            dependency-groups = [ ];
+          };
+        };
+      };
+    };
+
   loadWorkspace.mkPyprojectOverlay =
     let
       mkTest =

--- a/templates/hello-world/flake.nix
+++ b/templates/hello-world/flake.nix
@@ -75,9 +75,9 @@
     in
     {
       # Package a virtual environment as our main application.
-      packages.x86_64-linux.default = pythonSet.mkVirtualEnv "hello-world-env" {
-        hello-world = [ ];
-      };
+      #
+      # Enable no optional dependencies for production build.
+      packages.x86_64-linux.default = pythonSet.mkVirtualEnv "hello-world-env" workspace.deps.default;
 
       # This example provides two different modes of development:
       # - Impurely using uv to manage virtual environments
@@ -112,11 +112,10 @@
             # Override previous set with our overrideable overlay.
             editablePythonSet = pythonSet.overrideScope editableOverlay;
 
-            # Build virtual environment
-            virtualenv = editablePythonSet.mkVirtualEnv "hello-world-dev-env" {
-              # Add hello world with it's dev dependency group
-              hello-world = [ "dev" ];
-            };
+            # Build virtual environment, with local packages being editable.
+            #
+            # Enable all optional dependencies for development.
+            virtualenv = editablePythonSet.mkVirtualEnv "hello-world-dev-env" workspace.deps.all;
 
           in
           pkgs.mkShell {


### PR DESCRIPTION
This removes the need to manually type out which packages to include in a virtual environment:

``` nix
pythonSet.mkVirtualEnv "hello-world-env" {
  hello-world = [ ];
}
```

Now you can refer to a generated attribute set:
``` nix
pythonSet.mkVirtualEnv "hello-world-env" workspace.deps.default
```
to activate all workspace dependencies with no optional-dependencies or dependency-groups activated.

And to activate all optional-dependencies and dependency-groups:
``` nix
pythonSet.mkVirtualEnv "hello-world-dev-env" workspace.deps.all
```