### PR TITLE
doc: Fix mkApplication example, `util.mkApplication` should be `mkApplication`

### DIFF
--- a/doc/src/patterns/applications.md
+++ b/doc/src/patterns/applications.md
@@ -25,7 +25,7 @@ For such cases `pyproject.nix` provides a utility function [`mkApplication`](htt
         # - pyvenv.cfg
         #
         # Are excluded but things like binaries, man pages, systemd units etc are included.
-        default = util.mkApplication {
+        default = mkApplication {
           venv = pythonSet.mkVirtualEnv "application-env" workspace.deps.default;
           package = pythonSet.hello-world;
       };


### PR DESCRIPTION
In the `let` block we are `inherit`ing `mkApplication`, so it should be just `mkApplication` not `util.mkApplication`. As written, this doesn't run.