### PR TITLE
feat: support subdirectory for url sources

### DIFF
--- a/lib/build.nix
+++ b/lib/build.nix
@@ -358,6 +358,14 @@ in
         else
           throw "Unhandled state: could not derive src for package '${package.name}' from: ${toJSON source}";
 
+      subdirectory =
+        if (isGit && gitURL ? query.subdirectory) then
+          gitURL.query.subdirectory
+        else if isURL then
+          package.source.subdirectory or package.sdist.subdirectory or null
+        else
+          null;
+
     in
     # make sure there is no intersection between no-binary-packages and no-build-packages for current package
     assert assertMsg (!elem package.name unbuildable-packages) (
@@ -428,8 +436,8 @@ in
             darwinMinVersionHook stdenv.targetPlatform.darwinSdkVersion
           ));
       }
-      // optionalAttrs (isGit && gitURL ? query.subdirectory) {
-        sourceRoot = "source/${gitURL.query.subdirectory}";
+      // optionalAttrs (subdirectory != null) {
+        sourceRoot = "source/${subdirectory}";
       }
       // optionalAttrs stdenv.isDarwin {
         sandboxProfile = darwinSandboxProfile;


### PR DESCRIPTION
uv sources declarations can have a subdirectory when the source is url:

> URL dependencies can also be manually added or edited in the pyproject.toml with the `{ url = <url> }` syntax. A subdirectory may be specified if the source distribution isn't in the archive root.

-- https://docs.astral.sh/uv/concepts/projects/dependencies/#url

It looks like this in the uv.lock:

```
[[package]]
name = "brrr"
version = "0.1.1.dev0"
source = { url = "https://github.com/anteriorai/brrr/archive/64107b6898f1324cafaa02bff2b0a8d724037577.tar.gz", subdirectory = "python" }
dependencies = [
    { name = "bencode-py" },
]
sdist = { hash = "sha256:3a8e27dddf54f5f735ee4f29367b1b748837f397e2f22f1c5d50314b3e850383" }
```

(The subdirectory here being "python")
