### PR TITLE
fix: use override src for unzip detection

### DIFF
--- a/lib/build.nix
+++ b/lib/build.nix
@@ -375,6 +375,7 @@ in
     assert assertMsg (format == "wheel" -> !elem package.name no-binary-package)
       "Package source for '${package.name}' was derived as wheel, but was present in tool.uv.no-binary-package";
     stdenv.mkDerivation (
+      self:
       {
         pname = package.name;
         version = "0.0.0";
@@ -389,7 +390,7 @@ in
         };
 
         nativeBuildInputs =
-          optional (hasSuffix ".zip" (src.passthru.url or "")) unzip
+          optional (hasSuffix ".zip" (self.src.passthru.url or "")) unzip
           ++ optional (format == "pyproject") pyprojectHook
           ++ optional (format == "wheel") pyprojectWheelHook
           ++ optional (format == "wheel" && stdenv.isLinux) autoPatchelfHook;


### PR DESCRIPTION
Respect overrides when evaluating src

Particularly relevant when dealing with private sources which are overridden from the flake inputs