### PR TITLE
docs: fix example for multiple outputs

### DIFF
--- a/doc/src/patterns/dist.md
+++ b/doc/src/patterns/dist.md
@@ -10,7 +10,7 @@ The intermediate wheel file is normally discarded once the build is complete and
 Using [multiple outputs](https://nixos.org/manual/nixpkgs/stable/#chap-multiple-output) allows us to not only perform our regular install steps, but also to install the wheel files into a separate output.
 To add a separate dist output:
 ```nix
-pythonSet.hello-world.override (old: {
+pythonSet.hello-world.overrideAttrs (final: prev: {
   outputs = [ "out" "dist" ];
 })
 ```


### PR DESCRIPTION
This fixes the example for multiple outputs.

The first commit is fixing the typo.
The second commit fixes the logic - could be that I am doing something wrong, but for me only the `overrideAttrs` gives the described result :).