### PR TITLE
Fix and improve docs for source filtering

### DIFF
--- a/doc/src/patterns/source-filtering.md
+++ b/doc/src/patterns/source-filtering.md
@@ -9,6 +9,14 @@ Source selection/filtering is extra important for editable packages, which shoul
 
 Most Python build backends only require enough sources to discover what importable Python packages to provide for an editable build to succeed:
 ```nix
+let
+  # [...] workspace, overlay etc
+
+  editableOverlay = workspace.mkEditablePyprojectOverlay {
+    root = "$REPO_ROOT";
+  };
+
+  pyprojectOverrides = final: prev: {
     app = prev.app.overrideAttrs (old: {
       src = lib.fileset.toSource rec {
         root = ./.;
@@ -18,19 +26,53 @@ Most Python build backends only require enough sources to discover what importab
         ];
       };
     });
+  };
+
+  pythonSet = pythonBase.overrideScope (
+    lib.composeManyExtensions [
+      # ...
+      pyproject-build-systems.overlays.wheel
+      overlay
+      editableOverlay
+      pyprojectOverrides
+    ]
+  );
+
+  virtualenv = pythonSet.mkVirtualEnv "app-dev-env" workspace.deps.all;
+in
+  pkgs.mkShell {
+    packages = [
+      virtualenv
+      pkgs.uv
+    ];
+
+    env = {
+      UV_NO_SYNC = "1";
+      UV_PYTHON = pythonSet.python.interpreter;
+      UV_PYTHON_DOWNLOADS = "never";
+    };
+
+    shellHook = ''
+      unset PYTHONPATH
+      export REPO_ROOT=$(git rev-parse --show-toplevel)
+    '';
+  };
+}
 ```
 This example uses the [fileset](https://nix.dev/tutorials/working-with-local-files.html) API to explicitly select sources.
 
 Another way to reduce the amount of rebuilds even further is to construct dummy sources:
 ```nix
-  app = prev.app.overrideAttrs(old: {
-    src = pkgs.runCommand "app-src" {} ''
-      mkdir $out
-      cp ${./pyproject.toml} $out/pyproject.toml
-      mkdir $out/app
-      touch $out/app/__init__.py
-    '';
-  });
+  pyprojectOverrides = final: prev: {
+    app = prev.app.overrideAttrs(old: {
+      src = pkgs.runCommand "app-src" {} ''
+        mkdir $out
+        cp ${./pyproject.toml} $out/pyproject.toml
+        mkdir $out/app
+        touch $out/app/__init__.py
+      '';
+    });
+  };
 ```
 
 ## External resources


### PR DESCRIPTION
I was absolutely lost with the documentation, and I'm not new to Nix either.

When reading it, I Intuitively assumed that the minimal source derivation would have to be passed to `loadWorkspace` as `workspaceRoot`. This lead me on a wild goose chase trying to figure out why it didn't work (it's a derivation, and while I've got IFD enabled, the uv2nix code uses lib functions that can only work with path type values). Obviously I now get that uv2nix' usage of reading individual files from the user's flake (which are content-addressed) during evaluation is separate from the project's package in the pythonSet using the flake's entire store path (which changes with any file modification) as src.

IMHO, the documentation for source filtering should be combined with that for `workspace.mkEditablePyprojectOverlay`, because I can't imagine anyone using the latter without also wanting the former (why would you want to rebuild on source changes when you're not using the code from the build output anyway?)

Ideally, there would even be a helper function that does both. But there's a bit more work here, because the dummy files that need to be created depend on the module structure (also, a README is required if it's set in pyproject.toml)