### PR TITLE
build: Add opt-in forge fetchers for git sources

### DIFF
--- a/doc/src/patterns/private-deps.md
+++ b/doc/src/patterns/private-deps.md
@@ -1,6 +1,13 @@
 # Using private (authenticated) dependencies
 
+This page covers two related cases:
+
+- authenticated package indexes and artifact URLs
+- authenticated Git dependencies
+
 Uv2nix uses [pkgs.fetchurl](https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-fetchers-fetchurl) for fetching from PyPI, and inherits authentication support from nixpkgs.
+
+For Git dependencies, uv2nix can optionally map well-known forge URLs like GitHub and GitLab to Nix's forge-aware fetchers. For public repositories this behaves like an ordinary forge fetch. For private repositories it can let Nix use [`access-tokens`](https://nix.dev/manual/nix/stable/command-ref/conf-file.html#conf-access-tokens) from `nix.conf`, instead of relying on `netrc` files or Git credential helpers for `builtins.fetchGit`.
 
 Getting authentication running in the sandbox requires some system setup.
 
@@ -68,3 +75,54 @@ To build a package we need to provide our netrc file _inside_ the Nix sandbox.
 `nix build -L -v --option extra-sandbox-paths /etc/nix/netrc`
 
 For a persistent setup `extra-sandbox-paths` should be added to `nix.conf`.
+
+## Private Git dependencies via `access-tokens`
+
+When a package in `uv.lock` has a Git source such as:
+
+```toml
+source = { git = "https://github.com/my-org/private-lib.git?tag=v1.2.3#0123456789abcdef0123456789abcdef01234567" }
+```
+
+To opt in, set:
+
+```nix
+config.git-fetcher = "auto";
+```
+
+In `auto` mode uv2nix can detect the forge from the URL and prefer Nix's forge-aware fetcher.
+
+With this in `nix.conf`:
+
+```ini
+access-tokens = github.com=ghp_xxxxxxxxxxxxxxxxxxxx gitlab.example.com=PAT:glpat-xxxxxxxxxxxxxxxxxxxx
+```
+
+Nix can authenticate those fetches without extra Git-specific credential configuration.
+
+The default remains `git-fetcher = "git"`, which keeps using `builtins.fetchGit` with submodule-friendly behavior. This avoids changing behavior for existing projects and is the safer choice if a repository depends on Git submodules.
+
+For self-hosted forges, also tell uv2nix which host belongs to which forge:
+
+```nix
+config = {
+  git-fetcher = "auto";
+  git-forge-hosts."gitlab.example.com" = "gitlab";
+};
+```
+
+If you enable `auto` globally but need one repository to keep using `fetchGit`, add it to `git-fetcher-force-git`:
+
+```nix
+config = {
+  git-fetcher = "auto";
+  git-fetcher-force-git = [
+    "github.com/my-org/private-lib"
+    "gitlab.example.com/company/platform/internal-package"
+  ];
+};
+```
+
+Use this for repositories that require Git-specific behavior such as submodules. In that case you will still need Git-compatible credentials for `fetchGit`.
+
+Unknown Git hosts still fall back to `builtins.fetchGit`.

--- a/lib/build.nix
+++ b/lib/build.nix
@@ -1,4 +1,9 @@
-{ lib, pyproject-nix, ... }:
+{
+  lib,
+  fetchers,
+  pyproject-nix,
+  ...
+}:
 
 let
   inherit (lib)
@@ -8,13 +13,9 @@ let
     elem
     concatMap
     assertMsg
-    match
-    elemAt
     listToAttrs
-    splitString
     nameValuePair
     optionalAttrs
-    versionAtLeast
     findFirst
     optionals
     optional
@@ -28,88 +29,16 @@ let
   inherit (pyproject-nix.lib) pypa;
   inherit (builtins)
     toJSON
-    nixVersion
-    replaceStrings
     baseNameOf
     ;
 
-  parseGitURL =
-    url:
-    let
-      # With query params
-      m1 = match "([^?]+)\\?([^#]+)#(.+)" url;
-
-      # No query params
-      m2 = match "([^#]+)#(.+)" url;
-    in
-    if m1 != null then
-      {
-        url = elemAt m1 0;
-        query = listToAttrs (
-          map (
-            s:
-            let
-              parts = splitString "=" s;
-            in
-            assert length parts == 2;
-            nameValuePair (unquoteURL (elemAt parts 0)) (unquoteURL (elemAt parts 1))
-          ) (splitString "&" (elemAt m1 1))
-        );
-        fragment = unquoteURL (elemAt m1 2);
-      }
-    else if m2 != null then
-      {
-        url = elemAt m2 0;
-        query = { };
-        fragment = unquoteURL (elemAt m2 1);
-      }
-    else
-      throw "Could not parse git url: ${url}";
+  inherit (fetchers)
+    parseGitSource
+    selectGitFetcher
+    unquoteURL
+    ;
 
   mkSpec = dependencies: listToAttrs (map (dep: nameValuePair dep.name dep.extra) dependencies);
-
-  unquoteURL =
-    replaceStrings
-      [
-        "%21"
-        "%23"
-        "%24"
-        "%26"
-        "%27"
-        "%28"
-        "%29"
-        "%2A"
-        "%2B"
-        "%2C"
-        "%2F"
-        "%3A"
-        "%3B"
-        "%3D"
-        "%3F"
-        "%40"
-        "%5B"
-        "%5D"
-      ]
-      [
-        "!"
-        "#"
-        "$"
-        "&"
-        "'"
-        "("
-        ")"
-        "*"
-        "+"
-        ","
-        "/"
-        ":"
-        ";"
-        "="
-        "?"
-        "@"
-        "["
-        "]"
-      ];
 
   # Support code for extra-build-dependencies shared among both local & remote builds
   mkPackageExtraBuildDependencies =
@@ -277,6 +206,8 @@ in
       stdenv,
       python,
       fetchurl,
+      fetchGit ? builtins.fetchGit,
+      fetchTree ? builtins.fetchTree or null,
       autoPatchelfHook,
       pythonManylinuxPackages,
       unzip,
@@ -341,21 +272,25 @@ in
         else
           "pyproject";
 
-      gitURL = parseGitURL source.git;
+      gitSource = parseGitSource source.git;
 
       src =
         if isGit then
-          (fetchGit (
-            {
-              inherit (gitURL) url;
-              rev = gitURL.fragment;
+          let
+            parsedGitFetcher = selectGitFetcher {
+              inherit config;
+              hasFetchTree = fetchTree != null;
+            } gitSource;
+          in
+          if parsedGitFetcher.fetcher == "fetchTree" then
+            (fetchTree parsedGitFetcher.args)
+            // {
+              passthru = {
+                inherit (gitSource) url;
+              };
             }
-            // optionalAttrs (gitURL ? query.tag) { ref = "refs/tags/${gitURL.query.tag}"; }
-            // optionalAttrs (versionAtLeast nixVersion "2.4") {
-              allRefs = true;
-              submodules = true;
-            }
-          ))
+          else
+            fetchGit parsedGitFetcher.args
         else if isPath then
           {
             outPath = "${workspaceRoot + "/${source.path}"}";
@@ -405,8 +340,8 @@ in
           throw "Unhandled state: could not derive src for package '${package.name}' from: ${toJSON source}";
 
       subdirectory =
-        if (isGit && gitURL ? query.subdirectory) then
-          gitURL.query.subdirectory
+        if (isGit && gitSource ? query.subdirectory) then
+          gitSource.query.subdirectory
         else if isURL then
           package.source.subdirectory or package.sdist.subdirectory or null
         else

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -6,6 +6,7 @@ in
 fix (
   self:
   mapAttrs (_: path: import path ({ inherit lib pyproject-nix; } // self)) {
+    fetchers = ./fetchers.nix;
     lock1 = ./lock1.nix;
     workspace = ./workspace.nix;
     build = ./build.nix;

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -1,0 +1,378 @@
+{ lib, ... }:
+
+let
+  inherit (lib)
+    length
+    elem
+    head
+    tail
+    elemAt
+    concatStringsSep
+    match
+    listToAttrs
+    splitString
+    filter
+    nameValuePair
+    optionalAttrs
+    versionAtLeast
+    toLower
+    removeSuffix
+    ;
+  inherit (builtins)
+    nixVersion
+    map
+    replaceStrings
+    stringLength
+    substring
+    ;
+
+  splitOnce = separator: value: {
+    before = head (splitString separator value);
+    after =
+      let
+        parts = splitString separator value;
+      in
+      if length parts > 1 then concatStringsSep separator (tail parts) else null;
+  };
+
+  stripGitTransportPrefix =
+    url:
+    if stringLength url >= 4 && toLower (substring 0 4 url) == "git+" then
+      substring 4 ((stringLength url) - 4) url
+    else
+      url;
+
+  urlEscapePairs = [
+    {
+      encoded = "%20";
+      decoded = " ";
+    }
+    {
+      encoded = "%21";
+      decoded = "!";
+    }
+    {
+      encoded = "%23";
+      decoded = "#";
+    }
+    {
+      encoded = "%24";
+      decoded = "$";
+    }
+    {
+      encoded = "%26";
+      decoded = "&";
+    }
+    {
+      encoded = "%27";
+      decoded = "'";
+    }
+    {
+      encoded = "%28";
+      decoded = "(";
+    }
+    {
+      encoded = "%29";
+      decoded = ")";
+    }
+    {
+      encoded = "%2A";
+      decoded = "*";
+    }
+    {
+      encoded = "%2B";
+      decoded = "+";
+    }
+    {
+      encoded = "%2C";
+      decoded = ",";
+    }
+    {
+      encoded = "%2F";
+      decoded = "/";
+    }
+    {
+      encoded = "%3A";
+      decoded = ":";
+    }
+    {
+      encoded = "%3B";
+      decoded = ";";
+    }
+    {
+      encoded = "%3D";
+      decoded = "=";
+    }
+    {
+      encoded = "%3F";
+      decoded = "?";
+    }
+    {
+      encoded = "%40";
+      decoded = "@";
+    }
+    {
+      encoded = "%5B";
+      decoded = "[";
+    }
+    {
+      encoded = "%5D";
+      decoded = "]";
+    }
+  ];
+
+  unquoteURL = replaceStrings (
+    (map (pair: pair.encoded) urlEscapePairs) ++ (map (pair: toLower pair.encoded) urlEscapePairs)
+  ) ((map (pair: pair.decoded) urlEscapePairs) ++ (map (pair: pair.decoded) urlEscapePairs));
+
+  parseURLQuery =
+    query:
+    if query == null || query == "" then
+      { }
+    else
+      listToAttrs (
+        map (
+          param:
+          let
+            split = splitOnce "=" param;
+          in
+          nameValuePair (unquoteURL split.before) (
+            unquoteURL (if split.after != null then split.after else "")
+          )
+        ) (filter (param: param != "") (splitString "&" query))
+      );
+
+  isGitHash = value: match "[0-9a-fA-F]{7,40}" value != null;
+
+  defaultGitRef = query: query.ref or (query.branch or (query.tag or (query.rev or null)));
+
+  defaultFetchGitRef =
+    query:
+    query.ref or (
+      if query ? branch then
+        "refs/heads/${query.branch}"
+      else if query ? tag then
+        "refs/tags/${query.tag}"
+      else if query ? rev && !(isGitHash query.rev) then
+        query.rev
+      else
+        null
+    );
+
+  defaultLockedGitRev =
+    gitSource:
+    if gitSource.fragment != "" then
+      gitSource.fragment
+    else if gitSource.query ? rev && isGitHash gitSource.query.rev then
+      gitSource.query.rev
+    else
+      null;
+
+  stripAuthorityUserInfo =
+    authority:
+    let
+      parts = splitString "@" authority;
+    in
+    elemAt parts ((length parts) - 1);
+
+  encodePathSegmentSlashes = value: replaceStrings [ "/" ] [ "%2F" ] value;
+
+  normalizeGitPath =
+    path:
+    let
+      normalizedPath = removeSuffix ".git" (removeSuffix "/" path);
+      segments = filter (segment: segment != "") (splitString "/" normalizedPath);
+    in
+    if normalizedPath == "" || segments == [ ] then
+      null
+    else
+      {
+        path = normalizedPath;
+        inherit segments;
+      };
+
+  normalizeForcedGitRepo =
+    value:
+    let
+      split = splitOnce "/" value;
+      pathInfo = if split.after != null then normalizeGitPath split.after else null;
+    in
+    if split.after == null || split.before == "" || pathInfo == null then
+      null
+    else
+      "${toLower split.before}/${pathInfo.path}";
+
+  parseGitRemoteWithScheme =
+    scheme: rest:
+    let
+      authoritySplit = splitOnce "/" rest;
+    in
+    if
+      !elem scheme [
+        "http"
+        "https"
+        "ssh"
+        "git"
+      ]
+      || authoritySplit.after == null
+      || authoritySplit.before == ""
+    then
+      null
+    else
+      {
+        authority = authoritySplit.before;
+        path = authoritySplit.after;
+      };
+
+in
+rec {
+  inherit unquoteURL;
+
+  defaultGitForgeHosts = {
+    "github.com" = "github";
+    "gitlab.com" = "gitlab";
+    "git.sr.ht" = "sourcehut";
+  };
+
+  parseForgeProject =
+    forge: segments:
+    if forge == "github" || forge == "sourcehut" then
+      if length segments != 2 then
+        null
+      else
+        {
+          owner = head segments;
+          repo = elemAt segments 1;
+        }
+    else if forge == "gitlab" then
+      if length segments < 2 then
+        null
+      else
+        {
+          owner = encodePathSegmentSlashes (
+            concatStringsSep "/" (builtins.genList (i: elemAt segments i) ((length segments) - 1))
+          );
+          repo = elemAt segments ((length segments) - 1);
+        }
+    else
+      null;
+
+  parseGitSource =
+    source:
+    let
+      strippedSource = stripGitTransportPrefix source;
+      fragmentSplit = splitOnce "#" strippedSource;
+      querySplit = splitOnce "?" fragmentSplit.before;
+      gitSource = {
+        url = querySplit.before;
+        query = parseURLQuery querySplit.after;
+        fragment = unquoteURL (if fragmentSplit.after != null then fragmentSplit.after else "");
+      };
+    in
+    gitSource
+    // {
+      lockedRev = defaultLockedGitRev gitSource;
+      fetchGitRef = defaultFetchGitRef gitSource.query;
+      fetchTreeRef = defaultGitRef gitSource.query;
+    };
+
+  parseGitRemote =
+    url:
+    let
+      schemeSplit = splitOnce "://" url;
+      mScp = match "([^@/:]+@)?([^:/]+):(.+)" url;
+
+      parsed =
+        if schemeSplit.after != null then
+          parseGitRemoteWithScheme (toLower schemeSplit.before) schemeSplit.after
+        else if mScp != null then
+          {
+            authority = elemAt mScp 1;
+            path = elemAt mScp 2;
+          }
+        else
+          null;
+    in
+    if parsed == null then
+      null
+    else
+      let
+        authorityWithoutUser = stripAuthorityUserInfo parsed.authority;
+        authorityParts = splitString ":" authorityWithoutUser;
+        host = head authorityParts;
+        pathInfo = normalizeGitPath parsed.path;
+      in
+      if authorityWithoutUser == "" || pathInfo == null then
+        null
+      else
+        {
+          authority = toLower authorityWithoutUser;
+          inherit host;
+          hostLower = toLower host;
+          hasPort = length authorityParts > 1;
+          inherit (pathInfo) path segments;
+        };
+
+  selectGitFetcher =
+    {
+      config,
+      hasFetchTree ? false,
+    }:
+    gitSource:
+    let
+      gitFetcher = config.git-fetcher or "git";
+      gitForgeHosts = defaultGitForgeHosts // (config.git-forge-hosts or { });
+      gitFetcherForceGit = map normalizeForcedGitRepo (config.git-fetcher-force-git or [ ]);
+      parsed = parseGitRemote gitSource.url;
+      normalizedRepo = if parsed != null then "${parsed.hostLower}/${parsed.path}" else null;
+      forcedGit = normalizedRepo != null && elem normalizedRepo gitFetcherForceGit;
+      fetchGitArgs = {
+        inherit (gitSource) url;
+      }
+      // optionalAttrs (gitSource.lockedRev != null) { rev = gitSource.lockedRev; }
+      // optionalAttrs (gitSource.fetchGitRef != null) { ref = gitSource.fetchGitRef; }
+      // optionalAttrs (versionAtLeast nixVersion "2.4") {
+        allRefs = true;
+        submodules = true;
+      };
+      forge =
+        if parsed != null && !parsed.hasPort then
+          gitForgeHosts.${parsed.hostLower} or gitForgeHosts.${parsed.host} or null
+        else
+          null;
+      defaultHost =
+        if forge == "github" then
+          "github.com"
+        else if forge == "gitlab" then
+          "gitlab.com"
+        else if forge == "sourcehut" then
+          "git.sr.ht"
+        else
+          null;
+      hostAttrs = optionalAttrs (forge != null && parsed.hostLower != defaultHost) {
+        host = parsed.hostLower;
+      };
+      project = if forge != null then parseForgeProject forge parsed.segments else null;
+      fallback = {
+        fetcher = "fetchGit";
+        args = fetchGitArgs;
+      };
+    in
+    if gitFetcher != "auto" || forcedGit || !hasFetchTree || parsed == null || forge == null then
+      fallback
+    else if project == null then
+      fallback
+    else
+      {
+        fetcher = "fetchTree";
+        args = {
+          type = forge;
+          inherit (project) owner repo;
+        }
+        // optionalAttrs (gitSource.lockedRev != null) { rev = gitSource.lockedRev; }
+        // optionalAttrs (gitSource.lockedRev == null && gitSource.fetchTreeRef != null) {
+          ref = gitSource.fetchTreeRef;
+        }
+        // hostAttrs;
+      };
+}

--- a/lib/test.nix
+++ b/lib/test.nix
@@ -20,6 +20,7 @@ let
 in
 
 fix (self: {
+  fetchers = callTest ./test_fetchers.nix;
   lock1 = callTest ./test_lock1.nix;
   workspace = callTest ./test_workspace.nix;
   build = callTest ./test_build.nix;

--- a/lib/test_build.nix
+++ b/lib/test_build.nix
@@ -46,6 +46,56 @@ in
   remote =
     let
 
+      mkGitPackage =
+        {
+          source,
+          config ? { },
+        }:
+        let
+          buildRemotePackage =
+            build.remote
+              {
+                workspaceRoot = ./.;
+                config = {
+                  compile-bytecode = true;
+                  no-binary = false;
+                  no-build = false;
+                  no-binary-package = [ ];
+                  no-build-package = [ ];
+                  extra-build-dependencies = { };
+                }
+                // config;
+                defaultSourcePreference = "sdist";
+                environ = null;
+              }
+              {
+                name = "git-package";
+                version = "1.0.0";
+                inherit source;
+                dependencies = [ ];
+                optional-dependencies = { };
+                dev-dependencies = { };
+                sdist = { };
+                wheels = [ ];
+              };
+        in
+        pkgs.callPackage buildRemotePackage {
+          pyprojectHook = null;
+          pyprojectWheelHook = null;
+          python = pkgs.python312;
+          resolveBuildSystem = null;
+          fetchGit = args: {
+            fetcher = "fetchGit";
+            inherit args;
+            outPath = "/fetchGit";
+          };
+          fetchTree = args: {
+            fetcher = "fetchTree";
+            inherit args;
+            outPath = "/fetchTree";
+          };
+        };
+
       # Return a callPackage'd package.
       mkPackageTest =
         {
@@ -193,6 +243,161 @@ in
             ).src.url;
         expectedError.type = "ThrownError";
         expectedError.msg = "Package source for 'arpeggio' was derived as sdist, in tool.uv.no-binary is set to true";
+      };
+
+      testGitSourceDefaultsToFetchGit = {
+        expr =
+          let
+            drv = mkGitPackage {
+              source = {
+                git = "https://github.com/pypa/pip.git?tag=20.3.1#f94a429e17b450ac2d3432f46492416ac2cf58ad";
+              };
+            };
+          in
+          {
+            inherit (drv.src) fetcher;
+            inherit (drv.src.args) url;
+            inherit (drv.src.args) ref;
+            inherit (drv.src.args) rev;
+          };
+        expected = {
+          fetcher = "fetchGit";
+          url = "https://github.com/pypa/pip.git";
+          ref = "refs/tags/20.3.1";
+          rev = "f94a429e17b450ac2d3432f46492416ac2cf58ad";
+        };
+      };
+
+      testGitHubSourceUsesFetchTreeInAutoMode = {
+        expr =
+          let
+            drv = mkGitPackage {
+              source = {
+                git = "https://github.com/pypa/pip.git?tag=20.3.1#f94a429e17b450ac2d3432f46492416ac2cf58ad";
+              };
+              config.git-fetcher = "auto";
+            };
+          in
+          {
+            inherit (drv.src) fetcher;
+            inherit (drv.src.args) type;
+            inherit (drv.src.args) owner;
+            inherit (drv.src.args) repo;
+            inherit (drv.src.args) rev;
+          };
+        expected = {
+          fetcher = "fetchTree";
+          type = "github";
+          owner = "pypa";
+          repo = "pip";
+          rev = "f94a429e17b450ac2d3432f46492416ac2cf58ad";
+        };
+      };
+
+      testGitLabCustomHostUsesFetchTreeInAutoMode = {
+        expr =
+          let
+            drv = mkGitPackage {
+              source = {
+                git = "https://gitlab.example.com/company/platform/internal-package.git#0123456789abcdef0123456789abcdef01234567";
+              };
+              config = {
+                git-fetcher = "auto";
+                git-forge-hosts."gitlab.example.com" = "gitlab";
+              };
+            };
+          in
+          {
+            inherit (drv.src) fetcher;
+            inherit (drv.src.args) type;
+            inherit (drv.src.args) owner;
+            inherit (drv.src.args) repo;
+            inherit (drv.src.args) host;
+          };
+        expected = {
+          fetcher = "fetchTree";
+          type = "gitlab";
+          owner = "company%2Fplatform";
+          repo = "internal-package";
+          host = "gitlab.example.com";
+        };
+      };
+
+      testCustomHostConfigPreservesBuiltInHosts = {
+        expr =
+          let
+            drv = mkGitPackage {
+              source = {
+                git = "https://github.com/pypa/pip.git?tag=20.3.1#f94a429e17b450ac2d3432f46492416ac2cf58ad";
+              };
+              config = {
+                git-fetcher = "auto";
+                git-forge-hosts."gitlab.example.com" = "gitlab";
+              };
+            };
+          in
+          {
+            inherit (drv.src) fetcher;
+            inherit (drv.src.args) type;
+            inherit (drv.src.args) owner;
+            inherit (drv.src.args) repo;
+            inherit (drv.src.args) rev;
+          };
+        expected = {
+          fetcher = "fetchTree";
+          type = "github";
+          owner = "pypa";
+          repo = "pip";
+          rev = "f94a429e17b450ac2d3432f46492416ac2cf58ad";
+        };
+      };
+
+      testForceGitOverrideWinsInAutoMode = {
+        expr =
+          let
+            drv = mkGitPackage {
+              source = {
+                git = "https://github.com/pypa/pip.git?tag=20.3.1#f94a429e17b450ac2d3432f46492416ac2cf58ad";
+              };
+              config = {
+                git-fetcher = "auto";
+                git-fetcher-force-git = [ "github.com/pypa/pip" ];
+              };
+            };
+          in
+          {
+            inherit (drv.src) fetcher;
+            inherit (drv.src.args) url;
+            inherit (drv.src.args) ref;
+            inherit (drv.src.args) rev;
+          };
+        expected = {
+          fetcher = "fetchGit";
+          url = "https://github.com/pypa/pip.git";
+          ref = "refs/tags/20.3.1";
+          rev = "f94a429e17b450ac2d3432f46492416ac2cf58ad";
+        };
+      };
+
+      testUnknownGitHostFallsBackToFetchGit = {
+        expr =
+          let
+            drv = mkGitPackage {
+              source = {
+                git = "https://git.example.com/company/internal-package.git#0123456789abcdef0123456789abcdef01234567";
+              };
+            };
+          in
+          {
+            inherit (drv.src) fetcher;
+            inherit (drv.src.args) url;
+            inherit (drv.src.args) rev;
+          };
+        expected = {
+          fetcher = "fetchGit";
+          url = "https://git.example.com/company/internal-package.git";
+          rev = "0123456789abcdef0123456789abcdef01234567";
+        };
       };
     };
 

--- a/lib/test_fetchers.nix
+++ b/lib/test_fetchers.nix
@@ -1,0 +1,337 @@
+{ fetchers, ... }:
+
+{
+  unquoteURL = {
+    testCommonEscapes = {
+      expr = fetchers.unquoteURL "hello%2Fworld%3Fuser%40example.com";
+      expected = "hello/world?user@example.com";
+    };
+
+    testLowercaseEscapes = {
+      expr = fetchers.unquoteURL "release%2f2024%3fok%3dyes%20please";
+      expected = "release/2024?ok=yes please";
+    };
+  };
+
+  defaultGitForgeHosts = {
+    testDefaults = {
+      expr = fetchers.defaultGitForgeHosts;
+      expected = {
+        "github.com" = "github";
+        "gitlab.com" = "gitlab";
+        "git.sr.ht" = "sourcehut";
+      };
+    };
+  };
+
+  parseForgeProject = {
+    testGitHubProject = {
+      expr = fetchers.parseForgeProject "github" [
+        "pypa"
+        "pip"
+      ];
+      expected = {
+        owner = "pypa";
+        repo = "pip";
+      };
+    };
+
+    testGitLabNestedGroupProject = {
+      expr = fetchers.parseForgeProject "gitlab" [
+        "company"
+        "platform"
+        "internal-package"
+      ];
+      expected = {
+        owner = "company%2Fplatform";
+        repo = "internal-package";
+      };
+    };
+
+    testInvalidGitHubProject = {
+      expr = fetchers.parseForgeProject "github" [ "owner" ];
+      expected = null;
+    };
+  };
+
+  parseGitSource = {
+    testParsesGitPlusQueryAndFragment = {
+      expr = fetchers.parseGitSource "git+https://github.com/pypa/pip.git?tag=20.3.1#f94a429e17b450ac2d3432f46492416ac2cf58ad";
+      expected = {
+        url = "https://github.com/pypa/pip.git";
+        query = {
+          tag = "20.3.1";
+        };
+        fragment = "f94a429e17b450ac2d3432f46492416ac2cf58ad";
+        lockedRev = "f94a429e17b450ac2d3432f46492416ac2cf58ad";
+        fetchGitRef = "refs/tags/20.3.1";
+        fetchTreeRef = "20.3.1";
+      };
+    };
+
+    testUsesQueryRevWhenItIsHash = {
+      expr = fetchers.parseGitSource "https://example.com/repo.git?rev=0123456789abcdef0123456789abcdef01234567";
+      expected = {
+        url = "https://example.com/repo.git";
+        query = {
+          rev = "0123456789abcdef0123456789abcdef01234567";
+        };
+        fragment = "";
+        lockedRev = "0123456789abcdef0123456789abcdef01234567";
+        fetchGitRef = null;
+        fetchTreeRef = "0123456789abcdef0123456789abcdef01234567";
+      };
+    };
+
+    testDecodesLowercaseQueryEscapes = {
+      expr = fetchers.parseGitSource "https://example.com/repo.git?branch=release%2f2024&subdirectory=src%2fpython";
+      expected = {
+        url = "https://example.com/repo.git";
+        query = {
+          branch = "release/2024";
+          subdirectory = "src/python";
+        };
+        fragment = "";
+        lockedRev = null;
+        fetchGitRef = "refs/heads/release/2024";
+        fetchTreeRef = "release/2024";
+      };
+    };
+  };
+
+  parseGitRemote = {
+    testParsesScpLikeRemote = {
+      expr = fetchers.parseGitRemote "git@gitlab.example.com:company/platform/internal-package.git";
+      expected = {
+        authority = "gitlab.example.com";
+        host = "gitlab.example.com";
+        hostLower = "gitlab.example.com";
+        hasPort = false;
+        path = "company/platform/internal-package";
+        segments = [
+          "company"
+          "platform"
+          "internal-package"
+        ];
+      };
+    };
+
+    testParsesPortedHttpsRemote = {
+      expr = fetchers.parseGitRemote "https://gitlab.example.com:8443/company/internal-package.git";
+      expected = {
+        authority = "gitlab.example.com:8443";
+        host = "gitlab.example.com";
+        hostLower = "gitlab.example.com";
+        hasPort = true;
+        path = "company/internal-package";
+        segments = [
+          "company"
+          "internal-package"
+        ];
+      };
+    };
+
+    testParsesGitProtocolRemote = {
+      expr = fetchers.parseGitRemote "GIT://GitHub.com/pypa/pip.git";
+      expected = {
+        authority = "github.com";
+        host = "GitHub.com";
+        hostLower = "github.com";
+        hasPort = false;
+        path = "pypa/pip";
+        segments = [
+          "pypa"
+          "pip"
+        ];
+      };
+    };
+  };
+
+  selectGitFetcher = {
+    testDefaultsToFetchGit = {
+      expr =
+        fetchers.selectGitFetcher
+          {
+            config = { };
+            hasFetchTree = true;
+          }
+          (
+            fetchers.parseGitSource "https://github.com/pypa/pip.git#f94a429e17b450ac2d3432f46492416ac2cf58ad"
+          );
+      expected = {
+        fetcher = "fetchGit";
+        args = {
+          url = "https://github.com/pypa/pip.git";
+          rev = "f94a429e17b450ac2d3432f46492416ac2cf58ad";
+          allRefs = true;
+          submodules = true;
+        };
+      };
+    };
+
+    testGitHubUsesFetchTreeInAutoMode = {
+      expr =
+        fetchers.selectGitFetcher
+          {
+            config.git-fetcher = "auto";
+            hasFetchTree = true;
+          }
+          (
+            fetchers.parseGitSource "https://github.com/pypa/pip.git#f94a429e17b450ac2d3432f46492416ac2cf58ad"
+          );
+      expected = {
+        fetcher = "fetchTree";
+        args = {
+          type = "github";
+          owner = "pypa";
+          repo = "pip";
+          rev = "f94a429e17b450ac2d3432f46492416ac2cf58ad";
+        };
+      };
+    };
+
+    testCustomGitLabHostUsesFetchTreeInAutoMode = {
+      expr =
+        fetchers.selectGitFetcher
+          {
+            config.git-fetcher = "auto";
+            config.git-forge-hosts."gitlab.example.com" = "gitlab";
+            hasFetchTree = true;
+          }
+          (
+            fetchers.parseGitSource "https://gitlab.example.com/company/platform/internal-package.git#0123456789abcdef0123456789abcdef01234567"
+          );
+      expected = {
+        fetcher = "fetchTree";
+        args = {
+          type = "gitlab";
+          owner = "company%2Fplatform";
+          repo = "internal-package";
+          host = "gitlab.example.com";
+          rev = "0123456789abcdef0123456789abcdef01234567";
+        };
+      };
+    };
+
+    testCustomHostConfigPreservesBuiltInHosts = {
+      expr =
+        fetchers.selectGitFetcher
+          {
+            config = {
+              git-fetcher = "auto";
+              git-forge-hosts."gitlab.example.com" = "gitlab";
+            };
+            hasFetchTree = true;
+          }
+          (
+            fetchers.parseGitSource "https://github.com/pypa/pip.git#f94a429e17b450ac2d3432f46492416ac2cf58ad"
+          );
+      expected = {
+        fetcher = "fetchTree";
+        args = {
+          type = "github";
+          owner = "pypa";
+          repo = "pip";
+          rev = "f94a429e17b450ac2d3432f46492416ac2cf58ad";
+        };
+      };
+    };
+
+    testUnknownHostFallsBackToFetchGit = {
+      expr =
+        fetchers.selectGitFetcher
+          {
+            config = { };
+            hasFetchTree = true;
+          }
+          (
+            fetchers.parseGitSource "https://git.example.com/company/internal-package.git#0123456789abcdef0123456789abcdef01234567"
+          );
+      expected = {
+        fetcher = "fetchGit";
+        args = {
+          url = "https://git.example.com/company/internal-package.git";
+          rev = "0123456789abcdef0123456789abcdef01234567";
+          allRefs = true;
+          submodules = true;
+        };
+      };
+    };
+
+    testBranchWithoutLockedRevUsesFetchTreeRef = {
+      expr = fetchers.selectGitFetcher {
+        config.git-fetcher = "auto";
+        hasFetchTree = true;
+      } (fetchers.parseGitSource "https://github.com/pypa/pip.git?branch=main");
+      expected = {
+        fetcher = "fetchTree";
+        args = {
+          type = "github";
+          owner = "pypa";
+          repo = "pip";
+          ref = "main";
+        };
+      };
+    };
+
+    testMalformedRemoteFallsBackToFetchGit = {
+      expr = fetchers.selectGitFetcher {
+        config = { };
+        hasFetchTree = true;
+      } (fetchers.parseGitSource "not-a-url");
+      expected = {
+        fetcher = "fetchGit";
+        args = {
+          url = "not-a-url";
+          allRefs = true;
+          submodules = true;
+        };
+      };
+    };
+
+    testForceGitOverridesAuto = {
+      expr =
+        fetchers.selectGitFetcher
+          {
+            config = {
+              git-fetcher = "auto";
+              git-fetcher-force-git = [ "github.com/pypa/pip" ];
+            };
+            hasFetchTree = true;
+          }
+          (
+            fetchers.parseGitSource "https://github.com/pypa/pip.git#f94a429e17b450ac2d3432f46492416ac2cf58ad"
+          );
+      expected = {
+        fetcher = "fetchGit";
+        args = {
+          url = "https://github.com/pypa/pip.git";
+          rev = "f94a429e17b450ac2d3432f46492416ac2cf58ad";
+          allRefs = true;
+          submodules = true;
+        };
+      };
+    };
+
+    testAutoFallsBackWhenFetchTreeUnavailable = {
+      expr =
+        fetchers.selectGitFetcher
+          {
+            config.git-fetcher = "auto";
+            hasFetchTree = false;
+          }
+          (
+            fetchers.parseGitSource "https://github.com/pypa/pip.git#f94a429e17b450ac2d3432f46492416ac2cf58ad"
+          );
+      expected = {
+        fetcher = "fetchGit";
+        args = {
+          url = "https://github.com/pypa/pip.git";
+          rev = "f94a429e17b450ac2d3432f46492416ac2cf58ad";
+          allRefs = true;
+          submodules = true;
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
This adds an opt-in path for using Nix's forge-aware fetchers for git sources. 

My personal motivation to submit this is to make uv2nix more usable out-of-the-box at the company I work, which is full of private git repositories and where uv2nix is used in many different environments (nix eval happens in github actions, on local machines, on nixos vms, etc). 

As it stands, fetchGit, which is used under the hood by uv2nix, does not use `nix.conf` `access-tokens` to authenticate, but instead relies on setting up git credentials helpers (e.g. by running `gh auth setup-git`) or by setting up a `.netrc` file with a github access token. Any time there is something like this in a pyproject,

```toml
[tool.uv.sources]
private-package = { git = "https://github.com/my-org/private-package"}
```

.netrc or a git credentials helper must be set up for uv2nix to eval.

With this proposed changed, setting `config.git-fetcher = "auto"` allows uv2nix to map known forge URLs to forge-aware fetchers that use `access-tokens` from `nix.conf` instead.

We keep `fetchGit` as the default to not change behavior for existing users. There is also a `git-fetcher-force-git` escape hatch, plus additive `git-forge-hosts` overrides for custom forge hosts.

Note that fetchGit has real submodule support; the forge fetchers (type = "github", "gitlab", "sourcehut") do not. That gap is upstream in Nix, so it won't be easy to support submodules, and users should use the standard git fetcher for such repositories.

## Also included

- move git source parsing/fetcher selection into `lib.fetchers`
- add dedicated tests for parsing and fetcher selection
- document private git dependency handling in `doc/src/patterns/private-deps.md`

## Testing

- `nix fmt`
- `nix develop -c nix-unit --flake .#libTests.fetchers`
- `nix develop -c nix-unit --flake .#libTests.build`
- `nix develop -c nix-unit --flake .#libTests`
