### PR TITLE
fix(build): import pep508 from pyproject-nix.lib instead of build.lib

### DIFF
--- a/lib/build.nix
+++ b/lib/build.nix
@@ -24,7 +24,8 @@ let
     groupBy
     hasSuffix
     ;
-  inherit (pyproject-nix.build.lib) renderers pep508;
+  inherit (pyproject-nix.build.lib) renderers;
+  inherit (pyproject-nix.lib) pep508;
   inherit (pyproject-nix.lib) pypa;
   inherit (builtins)
     toJSON


### PR DESCRIPTION
Fix this error: https://gitlab.com/moduon/oca2nix/-/jobs/14198230449
